### PR TITLE
Corrected response errors and made them useful

### DIFF
--- a/src/main/java/uk/gov/homeoffice/emailapi/EmailApiApplication.java
+++ b/src/main/java/uk/gov/homeoffice/emailapi/EmailApiApplication.java
@@ -9,7 +9,11 @@ import io.dropwizard.setup.Environment;
 import io.federecio.dropwizard.swagger.SwaggerBundle;
 import io.federecio.dropwizard.swagger.SwaggerBundleConfiguration;
 import uk.gov.homeoffice.emailapi.healthcheck.EmailSendingHealthCheck;
+import uk.gov.homeoffice.emailapi.resources.EmailExceptionMapper;
 import uk.gov.homeoffice.emailapi.resources.EmailSendingResource;
+import uk.gov.homeoffice.emailapi.resources.InternetAddressParsingExceptionMapper;
+import uk.gov.homeoffice.emailapi.resources.TemplatePopulatorIOExceptionMapper;
+import uk.gov.homeoffice.emailapi.resources.TemplatePopulatorParsingExceptionMapper;
 import uk.gov.homeoffice.emailapi.service.TemplatedEmailSender;
 import uk.gov.homeoffice.emailapi.service.TemplatedEmailSenderImpl;
 import uk.gov.homeoffice.emailapi.templatedemailfactory.TemplatedEmailFactory;
@@ -22,7 +26,8 @@ import uk.gov.homeoffice.emailapi.templatedemailfactory.templating.FreemarkerTem
 import uk.gov.homeoffice.emailapi.templatedemailfactory.templating.TemplatePopulator;
 
 public class EmailApiApplication extends Application<EmailApiConfiguration> {
-    private final FreemarkerConfigFactoryImpl freemarkerConfigFactory = new FreemarkerConfigFactoryImpl();
+    private final FreemarkerConfigFactoryImpl freemarkerConfigFactory =
+        new FreemarkerConfigFactoryImpl();
 
     public static void main(String[] args) throws Exception {
         new EmailApiApplication().run(args);
@@ -36,14 +41,13 @@ public class EmailApiApplication extends Application<EmailApiConfiguration> {
     @Override
     public void initialize(Bootstrap<EmailApiConfiguration> bootstrap) {
         bootstrap.setConfigurationSourceProvider(
-                new SubstitutingSourceProvider(bootstrap.getConfigurationSourceProvider(),
-                        new EnvironmentVariableSubstitutor()
-                )
-        );
+            new SubstitutingSourceProvider(bootstrap.getConfigurationSourceProvider(),
+                new EnvironmentVariableSubstitutor()));
 
         bootstrap.addBundle(new SwaggerBundle<EmailApiConfiguration>() {
             @Override
-            protected SwaggerBundleConfiguration getSwaggerBundleConfiguration(EmailApiConfiguration configuration) {
+            protected SwaggerBundleConfiguration getSwaggerBundleConfiguration(
+                EmailApiConfiguration configuration) {
                 return configuration.swaggerBundleConfiguration;
             }
         });
@@ -52,27 +56,33 @@ public class EmailApiApplication extends Application<EmailApiConfiguration> {
 
     @Override
     public void run(EmailApiConfiguration configuration, Environment environment) {
+        environment.jersey().register(InternetAddressParsingExceptionMapper.class);
+        environment.jersey().register(TemplatePopulatorIOExceptionMapper.class);
+        environment.jersey().register(TemplatePopulatorParsingExceptionMapper.class);
+        environment.jersey().register(EmailExceptionMapper.class);
 
-        Configuration freemarkerConfig = freemarkerConfigFactory.buildFreemarkerConfig(configuration.getEmailTemplatePath());
+        Configuration freemarkerConfig =
+            freemarkerConfigFactory.buildFreemarkerConfig(configuration.getEmailTemplatePath());
 
-        TemplatePopulator freemarkerTemplateParser = new FreemarkerTemplatePopulatorImpl(freemarkerConfig);
+        TemplatePopulator freemarkerTemplateParser =
+            new FreemarkerTemplatePopulatorImpl(freemarkerConfig);
         InternetAddressParser internetAddressParser = new InternetAddressParserImpl();
-        HtmlEmailFactory htmlEmailFactory = new HtmlEmailFactoryImpl(
-                configuration.getHostname(),
-                configuration.getPort(),
-                configuration.getUsername(),
-                configuration.getPassword(),
-                configuration.getOnSslConnect(),
-                configuration.getStartTslEnabled(),
-                configuration.getRequireTsl()
-        );
+        HtmlEmailFactory htmlEmailFactory =
+            new HtmlEmailFactoryImpl(configuration.getHostname(), configuration.getPort(),
+                configuration.getUsername(), configuration.getPassword(),
+                configuration.getOnSslConnect(), configuration.getStartTslEnabled(),
+                configuration.getRequireTsl());
 
-        TemplatedEmailFactory templatedEmailFactory = new TemplatedEmailFactoryImpl(freemarkerTemplateParser, internetAddressParser, htmlEmailFactory);
-        TemplatedEmailSender templatedEmailSender = new TemplatedEmailSenderImpl(templatedEmailFactory);
+        TemplatedEmailFactory templatedEmailFactory =
+            new TemplatedEmailFactoryImpl(freemarkerTemplateParser, internetAddressParser,
+                htmlEmailFactory);
+        TemplatedEmailSender templatedEmailSender =
+            new TemplatedEmailSenderImpl(templatedEmailFactory);
 
         final EmailSendingResource resource = new EmailSendingResource(templatedEmailSender);
         environment.jersey().register(resource);
-        environment.healthChecks().register("smtp-server", new EmailSendingHealthCheck(htmlEmailFactory));
+        environment.healthChecks()
+            .register("smtp-server", new EmailSendingHealthCheck(htmlEmailFactory));
     }
 
 }

--- a/src/main/java/uk/gov/homeoffice/emailapi/EmailApiConfiguration.java
+++ b/src/main/java/uk/gov/homeoffice/emailapi/EmailApiConfiguration.java
@@ -7,8 +7,7 @@ import org.hibernate.validator.constraints.NotEmpty;
 
 public class EmailApiConfiguration extends Configuration {
 
-    @JsonProperty("swagger")
-    public SwaggerBundleConfiguration swaggerBundleConfiguration;
+    @JsonProperty("swagger") public SwaggerBundleConfiguration swaggerBundleConfiguration;
 
     private String emailTemplatePath;
     private String hostname;

--- a/src/main/java/uk/gov/homeoffice/emailapi/entities/EmailApiStatus.java
+++ b/src/main/java/uk/gov/homeoffice/emailapi/entities/EmailApiStatus.java
@@ -1,0 +1,56 @@
+package uk.gov.homeoffice.emailapi.entities;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import javax.ws.rs.core.Response.Status;
+import javax.ws.rs.core.Response.StatusType;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public enum EmailApiStatus implements StatusType {
+    InvalidEmail(422, "Invalid recipient email"),
+    TemplateUnreadable(422, "Template does not exist"),
+    TemplateInvalid(422, "Template Invalid"),
+    SendingEmailFailed(Status.INTERNAL_SERVER_ERROR.getStatusCode(),
+        "Failed sending email to SMTP server.");
+
+    private final Status.Family family;
+
+    private final String reason;
+
+    private final int code;
+
+    EmailApiStatus(final int statusCode, final String reasonPhrase) {
+        this.code = statusCode;
+        this.reason = reasonPhrase;
+        this.family = Status.Family.familyOf(statusCode);
+    }
+
+    @JsonValue
+    public Map<String, List<String>> toEntity() {
+
+        Map<String, List<String>> map = new HashMap<>();
+        List<String> errors = new ArrayList<>();
+        errors.add(reason);
+        map.put("errors", errors);
+
+        return map;
+    }
+
+    @Override
+    public int getStatusCode() {
+        return code;
+    }
+
+    @Override
+    public Status.Family getFamily() {
+        return family;
+    }
+
+    @Override
+    public String getReasonPhrase() {
+        return reason;
+    }
+}

--- a/src/main/java/uk/gov/homeoffice/emailapi/entities/TemplatedEmailImpl.java
+++ b/src/main/java/uk/gov/homeoffice/emailapi/entities/TemplatedEmailImpl.java
@@ -2,37 +2,32 @@ package uk.gov.homeoffice.emailapi.entities;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import org.hibernate.validator.constraints.Email;
+import org.hibernate.validator.constraints.NotEmpty;
 
 import java.util.Collection;
 import java.util.Map;
 
 public class TemplatedEmailImpl implements TemplatedEmail {
 
-    @JsonProperty
-    private final Collection<String> recipients;
+    @JsonProperty @NotEmpty private final Collection<String> recipients;
 
-    @JsonProperty
-    private final String sender;
+    @JsonProperty @Email private final String sender;
 
-    @JsonProperty
-    private final String subject;
+    @JsonProperty @NotEmpty private final String subject;
 
-    @JsonProperty
-    private final String htmlTemplate;
+    @JsonProperty @NotEmpty private final String htmlTemplate;
 
-    @JsonProperty
-    private final Map<String, Object> variables;
+    @JsonProperty private final Map<String, Object> variables;
 
-    @JsonProperty
-    private final String textTemplate;
+    @JsonProperty @NotEmpty private final String textTemplate;
 
     @JsonCreator
     public TemplatedEmailImpl(@JsonProperty("recipients") Collection<String> recipients,
-                              @JsonProperty("sender") String sender,
-                              @JsonProperty("subject") String subject,
-                              @JsonProperty("htmlTemplate") String htmlTemplate,
-                              @JsonProperty("variables") Map<String, Object> variables,
-                              @JsonProperty("textTemplate") String textTemplate) {
+        @JsonProperty("sender") String sender, @JsonProperty("subject") String subject,
+        @JsonProperty("htmlTemplate") String htmlTemplate,
+        @JsonProperty("variables") Map<String, Object> variables,
+        @JsonProperty("textTemplate") String textTemplate) {
 
         this.recipients = recipients;
         this.sender = sender;

--- a/src/main/java/uk/gov/homeoffice/emailapi/resources/EmailExceptionMapper.java
+++ b/src/main/java/uk/gov/homeoffice/emailapi/resources/EmailExceptionMapper.java
@@ -1,0 +1,26 @@
+package uk.gov.homeoffice.emailapi.resources;
+
+import org.apache.commons.mail.EmailException;
+import org.slf4j.LoggerFactory;
+import uk.gov.homeoffice.emailapi.entities.EmailApiStatus;
+
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.ext.Provider;
+
+@Provider
+public class EmailExceptionMapper implements ExceptionMapper<EmailException> {
+
+    private static final org.slf4j.Logger LOGGER =
+        LoggerFactory.getLogger(EmailExceptionMapper.class);
+
+
+    @Override
+    public Response toResponse(EmailException exception) {
+        LOGGER.error("Failed to connect to SMTP server", exception);
+
+        return Response.status(EmailApiStatus.SendingEmailFailed)
+            .encoding(MediaType.APPLICATION_JSON).entity(EmailApiStatus.SendingEmailFailed).build();
+    }
+}

--- a/src/main/java/uk/gov/homeoffice/emailapi/resources/EmailSendingResource.java
+++ b/src/main/java/uk/gov/homeoffice/emailapi/resources/EmailSendingResource.java
@@ -9,15 +9,16 @@ import com.wordnik.swagger.annotations.ApiResponses;
 import org.apache.commons.mail.EmailException;
 import uk.gov.homeoffice.emailapi.entities.TemplatedEmail;
 import uk.gov.homeoffice.emailapi.service.TemplatedEmailSender;
-import uk.gov.homeoffice.emailapi.templatedemailfactory.TemplatedEmailFactoryException;
+import uk.gov.homeoffice.emailapi.templatedemailfactory.addressParsing.InternetAddressParsingException;
+import uk.gov.homeoffice.emailapi.templatedemailfactory.templating.TemplatePopulatorIOException;
+import uk.gov.homeoffice.emailapi.templatedemailfactory.templating.TemplatePopulatorParsingException;
 
+import javax.validation.Valid;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
-import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
 
 @Path("/outbound")
 @Api("/outbound")
@@ -32,18 +33,16 @@ public class EmailSendingResource {
     }
 
     @ApiResponses(value = {@ApiResponse(code = 204, message = "Successfully sent"),
-        @ApiResponse(code = 400, message = "Invalid Email Template Request Sent, or Template in request does not exist"),
+        @ApiResponse(code = 442, message = "Posted entity is not valid in some way (See message for details)"),
         @ApiResponse(code = 500, message = "Email failed to send")})
     @POST
     @Timed
     @ApiOperation("Send an email based on a template")
-    public void sendEmail(@ApiParam("Email template and params") TemplatedEmail templatedEmail)
-        throws WebApplicationException, EmailException {
+    public void sendEmail(
+        @ApiParam("Email template and params") @Valid TemplatedEmail templatedEmail)
+        throws EmailException, TemplatePopulatorParsingException, TemplatePopulatorIOException,
+        InternetAddressParsingException {
 
-        try {
-            templatedEmailSender.sendEmail(templatedEmail);
-        } catch (TemplatedEmailFactoryException e) {
-            throw new WebApplicationException(e, Response.Status.BAD_REQUEST);
-        }
+        templatedEmailSender.sendEmail(templatedEmail);
     }
 }

--- a/src/main/java/uk/gov/homeoffice/emailapi/resources/InternetAddressParsingExceptionMapper.java
+++ b/src/main/java/uk/gov/homeoffice/emailapi/resources/InternetAddressParsingExceptionMapper.java
@@ -1,0 +1,26 @@
+package uk.gov.homeoffice.emailapi.resources;
+
+import org.slf4j.LoggerFactory;
+import uk.gov.homeoffice.emailapi.entities.EmailApiStatus;
+import uk.gov.homeoffice.emailapi.templatedemailfactory.addressParsing.InternetAddressParsingException;
+
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.ext.Provider;
+
+@Provider
+public class InternetAddressParsingExceptionMapper
+    implements ExceptionMapper<InternetAddressParsingException> {
+
+    private static final org.slf4j.Logger LOGGER =
+        LoggerFactory.getLogger(InternetAddressParsingExceptionMapper.class);
+
+    @Override
+    public Response toResponse(InternetAddressParsingException exception) {
+        LOGGER.warn("Invalid recipient email passed to API", exception);
+
+        return Response.status(EmailApiStatus.InvalidEmail).encoding(MediaType.APPLICATION_JSON)
+            .entity(EmailApiStatus.InvalidEmail).build();
+    }
+}

--- a/src/main/java/uk/gov/homeoffice/emailapi/resources/TemplatePopulatorIOExceptionMapper.java
+++ b/src/main/java/uk/gov/homeoffice/emailapi/resources/TemplatePopulatorIOExceptionMapper.java
@@ -1,0 +1,26 @@
+package uk.gov.homeoffice.emailapi.resources;
+
+import org.slf4j.LoggerFactory;
+import uk.gov.homeoffice.emailapi.entities.EmailApiStatus;
+import uk.gov.homeoffice.emailapi.templatedemailfactory.templating.TemplatePopulatorIOException;
+
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.ext.Provider;
+
+@Provider
+public class TemplatePopulatorIOExceptionMapper
+    implements ExceptionMapper<TemplatePopulatorIOException> {
+
+    private static final org.slf4j.Logger LOGGER =
+        LoggerFactory.getLogger(TemplatePopulatorIOException.class);
+
+    @Override
+    public Response toResponse(TemplatePopulatorIOException exception) {
+        LOGGER.warn("Attempting to load non-existent template", exception);
+
+        return Response.status(EmailApiStatus.TemplateUnreadable)
+            .entity(EmailApiStatus.TemplateUnreadable).encoding(MediaType.APPLICATION_JSON).build();
+    }
+}

--- a/src/main/java/uk/gov/homeoffice/emailapi/resources/TemplatePopulatorParsingExceptionMapper.java
+++ b/src/main/java/uk/gov/homeoffice/emailapi/resources/TemplatePopulatorParsingExceptionMapper.java
@@ -1,0 +1,27 @@
+package uk.gov.homeoffice.emailapi.resources;
+
+import org.slf4j.LoggerFactory;
+import uk.gov.homeoffice.emailapi.entities.EmailApiStatus;
+import uk.gov.homeoffice.emailapi.templatedemailfactory.templating.TemplatePopulatorParsingException;
+
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.ext.Provider;
+
+@Provider
+public class TemplatePopulatorParsingExceptionMapper
+    implements ExceptionMapper<TemplatePopulatorParsingException> {
+
+
+    private static final org.slf4j.Logger LOGGER =
+        LoggerFactory.getLogger(TemplatePopulatorParsingExceptionMapper.class);
+
+    @Override
+    public Response toResponse(TemplatePopulatorParsingException exception) {
+        LOGGER.error("Template is broken", exception);
+
+        return Response.status(EmailApiStatus.TemplateInvalid).encoding(MediaType.APPLICATION_JSON)
+            .entity(EmailApiStatus.TemplateInvalid).build();
+    }
+}

--- a/src/main/java/uk/gov/homeoffice/emailapi/service/TemplatedEmailSender.java
+++ b/src/main/java/uk/gov/homeoffice/emailapi/service/TemplatedEmailSender.java
@@ -2,8 +2,12 @@ package uk.gov.homeoffice.emailapi.service;
 
 import org.apache.commons.mail.EmailException;
 import uk.gov.homeoffice.emailapi.entities.TemplatedEmail;
-import uk.gov.homeoffice.emailapi.templatedemailfactory.TemplatedEmailFactoryException;
+import uk.gov.homeoffice.emailapi.templatedemailfactory.addressParsing.InternetAddressParsingException;
+import uk.gov.homeoffice.emailapi.templatedemailfactory.templating.TemplatePopulatorIOException;
+import uk.gov.homeoffice.emailapi.templatedemailfactory.templating.TemplatePopulatorParsingException;
 
 public interface TemplatedEmailSender {
-    void sendEmail(TemplatedEmail templatedEmail) throws TemplatedEmailFactoryException, EmailException;
+    void sendEmail(TemplatedEmail templatedEmail)
+        throws EmailException, TemplatePopulatorParsingException, TemplatePopulatorIOException,
+        InternetAddressParsingException;
 }

--- a/src/main/java/uk/gov/homeoffice/emailapi/service/TemplatedEmailSenderImpl.java
+++ b/src/main/java/uk/gov/homeoffice/emailapi/service/TemplatedEmailSenderImpl.java
@@ -3,7 +3,9 @@ package uk.gov.homeoffice.emailapi.service;
 import org.apache.commons.mail.EmailException;
 import uk.gov.homeoffice.emailapi.entities.TemplatedEmail;
 import uk.gov.homeoffice.emailapi.templatedemailfactory.TemplatedEmailFactory;
-import uk.gov.homeoffice.emailapi.templatedemailfactory.TemplatedEmailFactoryException;
+import uk.gov.homeoffice.emailapi.templatedemailfactory.addressParsing.InternetAddressParsingException;
+import uk.gov.homeoffice.emailapi.templatedemailfactory.templating.TemplatePopulatorIOException;
+import uk.gov.homeoffice.emailapi.templatedemailfactory.templating.TemplatePopulatorParsingException;
 
 public class TemplatedEmailSenderImpl implements TemplatedEmailSender {
     private final TemplatedEmailFactory templatedEmailFactory;
@@ -13,7 +15,9 @@ public class TemplatedEmailSenderImpl implements TemplatedEmailSender {
     }
 
     @Override
-    public void sendEmail(TemplatedEmail templatedEmail) throws TemplatedEmailFactoryException, EmailException {
+    public void sendEmail(TemplatedEmail templatedEmail)
+        throws EmailException, TemplatePopulatorParsingException, TemplatePopulatorIOException,
+        InternetAddressParsingException {
         templatedEmailFactory.build(templatedEmail).send();
     }
 }

--- a/src/main/java/uk/gov/homeoffice/emailapi/templatedemailfactory/TemplatedEmailFactory.java
+++ b/src/main/java/uk/gov/homeoffice/emailapi/templatedemailfactory/TemplatedEmailFactory.java
@@ -1,8 +1,14 @@
 package uk.gov.homeoffice.emailapi.templatedemailfactory;
 
 import org.apache.commons.mail.Email;
+import org.apache.commons.mail.EmailException;
 import uk.gov.homeoffice.emailapi.entities.TemplatedEmail;
+import uk.gov.homeoffice.emailapi.templatedemailfactory.addressParsing.InternetAddressParsingException;
+import uk.gov.homeoffice.emailapi.templatedemailfactory.templating.TemplatePopulatorIOException;
+import uk.gov.homeoffice.emailapi.templatedemailfactory.templating.TemplatePopulatorParsingException;
 
 public interface TemplatedEmailFactory {
-    Email build(TemplatedEmail templatedEmail) throws TemplatedEmailFactoryException;
+    Email build(TemplatedEmail templatedEmail)
+        throws EmailException, TemplatePopulatorParsingException, TemplatePopulatorIOException,
+        InternetAddressParsingException;
 }

--- a/src/main/java/uk/gov/homeoffice/emailapi/templatedemailfactory/TemplatedEmailFactoryException.java
+++ b/src/main/java/uk/gov/homeoffice/emailapi/templatedemailfactory/TemplatedEmailFactoryException.java
@@ -1,7 +1,0 @@
-package uk.gov.homeoffice.emailapi.templatedemailfactory;
-
-public class TemplatedEmailFactoryException extends Exception {
-    public TemplatedEmailFactoryException(Throwable cause) {
-        super(cause);
-    }
-}

--- a/src/main/java/uk/gov/homeoffice/emailapi/templatedemailfactory/addressParsing/InternetAddressParser.java
+++ b/src/main/java/uk/gov/homeoffice/emailapi/templatedemailfactory/addressParsing/InternetAddressParser.java
@@ -5,5 +5,6 @@ import java.util.Collection;
 
 public interface InternetAddressParser {
 
-    Collection<InternetAddress> getInternetAddresses(Collection<String> unparsedRecipients) throws InternetAddressParsingException;
+    Collection<InternetAddress> getInternetAddresses(Collection<String> unparsedRecipients)
+        throws InternetAddressParsingException;
 }

--- a/src/main/java/uk/gov/homeoffice/emailapi/templatedemailfactory/addressParsing/InternetAddressParserImpl.java
+++ b/src/main/java/uk/gov/homeoffice/emailapi/templatedemailfactory/addressParsing/InternetAddressParserImpl.java
@@ -7,17 +7,25 @@ import java.util.Collection;
 
 public class InternetAddressParserImpl implements InternetAddressParser {
 
-    public Collection<InternetAddress> getInternetAddresses(Collection<String> unparsedRecipients) throws InternetAddressParsingException {
+    public Collection<InternetAddress> getInternetAddresses(Collection<String> unparsedRecipients)
+        throws InternetAddressParsingException {
+
         Collection<InternetAddress> recipients = new ArrayList<>();
 
         for (String emailAddress : unparsedRecipients) {
-            try {
-                recipients.add(new InternetAddress(emailAddress));
-            } catch (AddressException e) {
-                throw new InternetAddressParsingException(e);
-            }
+            recipients.add(getInternetAddress(emailAddress));
         }
 
         return recipients;
+    }
+
+    private InternetAddress getInternetAddress(String sender)
+        throws InternetAddressParsingException {
+
+        try {
+            return new InternetAddress(sender);
+        } catch (AddressException e) {
+            throw new InternetAddressParsingException(e);
+        }
     }
 }

--- a/src/main/java/uk/gov/homeoffice/emailapi/templatedemailfactory/serverconfig/HtmlEmailFactoryImpl.java
+++ b/src/main/java/uk/gov/homeoffice/emailapi/templatedemailfactory/serverconfig/HtmlEmailFactoryImpl.java
@@ -13,7 +13,8 @@ public class HtmlEmailFactoryImpl implements HtmlEmailFactory {
     private final boolean startTslEnabled;
     private final boolean requireTsl;
 
-    public HtmlEmailFactoryImpl(String hostname, int port, String username, String password, boolean sslOnConnect, boolean startTslEnabled, boolean requireTsl) {
+    public HtmlEmailFactoryImpl(String hostname, int port, String username, String password,
+        boolean sslOnConnect, boolean startTslEnabled, boolean requireTsl) {
         this.hostname = hostname;
         this.port = port;
         this.username = username;

--- a/src/main/java/uk/gov/homeoffice/emailapi/templatedemailfactory/templating/FreemarkerTemplatePopulatorImpl.java
+++ b/src/main/java/uk/gov/homeoffice/emailapi/templatedemailfactory/templating/FreemarkerTemplatePopulatorImpl.java
@@ -15,15 +15,26 @@ public class FreemarkerTemplatePopulatorImpl implements TemplatePopulator {
         this.freemarkerConfig = freemarkerConfig;
     }
 
-    public String populateTemplate(String templateName, Map<String, Object> variables) throws TemplatePopulatorException {
+    public String populateTemplate(String templateName, Map<String, Object> variables)
+        throws TemplatePopulatorIOException, TemplatePopulatorParsingException {
         try {
             Template template = freemarkerConfig.getTemplate(templateName);
             StringWriter out = new StringWriter();
             template.process(variables, out);
 
-            return out.toString();
-        } catch (IOException | TemplateException e) {
-            throw new TemplatePopulatorException(e);
+            String parsedTemplate = out.toString();
+
+            if (parsedTemplate.trim().isEmpty()) {
+                // Emails can never be empty
+                throw new TemplatePopulatorParsingException(
+                    "Template is Empty, emails can never be empty");
+            }
+
+            return parsedTemplate;
+        } catch (IOException e) {
+            throw new TemplatePopulatorIOException(e);
+        } catch (TemplateException e) {
+            throw new TemplatePopulatorParsingException(e);
         }
     }
 }

--- a/src/main/java/uk/gov/homeoffice/emailapi/templatedemailfactory/templating/TemplatePopulator.java
+++ b/src/main/java/uk/gov/homeoffice/emailapi/templatedemailfactory/templating/TemplatePopulator.java
@@ -3,5 +3,6 @@ package uk.gov.homeoffice.emailapi.templatedemailfactory.templating;
 import java.util.Map;
 
 public interface TemplatePopulator {
-    String populateTemplate(String template, Map<String, Object> variables) throws TemplatePopulatorException;
+    String populateTemplate(String template, Map<String, Object> variables)
+        throws TemplatePopulatorIOException, TemplatePopulatorParsingException;
 }

--- a/src/main/java/uk/gov/homeoffice/emailapi/templatedemailfactory/templating/TemplatePopulatorException.java
+++ b/src/main/java/uk/gov/homeoffice/emailapi/templatedemailfactory/templating/TemplatePopulatorException.java
@@ -1,7 +1,0 @@
-package uk.gov.homeoffice.emailapi.templatedemailfactory.templating;
-
-public class TemplatePopulatorException extends Exception {
-    public TemplatePopulatorException(Throwable cause) {
-        super(cause);
-    }
-}

--- a/src/main/java/uk/gov/homeoffice/emailapi/templatedemailfactory/templating/TemplatePopulatorIOException.java
+++ b/src/main/java/uk/gov/homeoffice/emailapi/templatedemailfactory/templating/TemplatePopulatorIOException.java
@@ -1,0 +1,8 @@
+package uk.gov.homeoffice.emailapi.templatedemailfactory.templating;
+
+
+public class TemplatePopulatorIOException extends Exception {
+    public TemplatePopulatorIOException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/src/main/java/uk/gov/homeoffice/emailapi/templatedemailfactory/templating/TemplatePopulatorParsingException.java
+++ b/src/main/java/uk/gov/homeoffice/emailapi/templatedemailfactory/templating/TemplatePopulatorParsingException.java
@@ -1,0 +1,11 @@
+package uk.gov.homeoffice.emailapi.templatedemailfactory.templating;
+
+public class TemplatePopulatorParsingException extends Exception {
+    public TemplatePopulatorParsingException(Throwable cause) {
+        super(cause);
+    }
+
+    public TemplatePopulatorParsingException(String message) {
+        super(message);
+    }
+}

--- a/src/test/java/uk/gov/homeoffice/emailapi/entities/TemplatedEmailImplTest.java
+++ b/src/test/java/uk/gov/homeoffice/emailapi/entities/TemplatedEmailImplTest.java
@@ -29,28 +29,32 @@ public class TemplatedEmailImplTest {
 
     @Test
     public void it_has_a_subject() {
-        TemplatedEmailImpl subject = new TemplatedEmailImpl(null, null, "subject", null, null, null);
+        TemplatedEmailImpl subject =
+            new TemplatedEmailImpl(null, null, "subject", null, null, null);
 
         assertThat(subject.getSubject(), equalTo("subject"));
     }
 
     @Test
     public void it_has_a_html_template() {
-        TemplatedEmailImpl subject = new TemplatedEmailImpl(null, null, null, "html template", null, null);
+        TemplatedEmailImpl subject =
+            new TemplatedEmailImpl(null, null, null, "html template", null, null);
 
         assertThat(subject.getHtmlTemplate(), equalTo("html template"));
     }
 
     @Test
     public void it_has_a_txt_template() {
-        TemplatedEmailImpl subject = new TemplatedEmailImpl(null, null, null, null, null, "txt template");
+        TemplatedEmailImpl subject =
+            new TemplatedEmailImpl(null, null, null, null, null, "txt template");
 
         assertThat(subject.getTextTemplate(), equalTo("txt template"));
     }
 
     @Test
     public void it_has_variables() {
-        TemplatedEmailImpl subject = new TemplatedEmailImpl(null, null, null, null, new HashMap<>(), null);
+        TemplatedEmailImpl subject =
+            new TemplatedEmailImpl(null, null, null, null, new HashMap<>(), null);
 
         assertThat(subject.getVariables(), instanceOf(HashMap.class));
     }

--- a/src/test/java/uk/gov/homeoffice/emailapi/templatedemailfactory/TemplatedEmailFactoryImplTest.java
+++ b/src/test/java/uk/gov/homeoffice/emailapi/templatedemailfactory/TemplatedEmailFactoryImplTest.java
@@ -34,33 +34,29 @@ public class TemplatedEmailFactoryImplTest {
         internetAddresses = new ArrayList<>();
 
         InternetAddressParser internetAddressParser = mock(InternetAddressParser.class);
-        when(internetAddressParser.getInternetAddresses(Matchers.<Collection<String>>any())).thenReturn(internetAddresses);
+        when(internetAddressParser.getInternetAddresses(Matchers.<Collection<String>>any()))
+            .thenReturn(internetAddresses);
 
 
         HtmlEmailFactory htmlEmailFactory = mock(HtmlEmailFactory.class);
         when(htmlEmailFactory.getHtmlEmail()).thenReturn(mock(HtmlEmail.class, CALLS_REAL_METHODS));
 
-        templatedEmailFactory = new TemplatedEmailFactoryImpl(
-                templatePopulator,
-                internetAddressParser,
-                htmlEmailFactory
-        );
+        templatedEmailFactory =
+            new TemplatedEmailFactoryImpl(templatePopulator, internetAddressParser,
+                htmlEmailFactory);
     }
 
     @Test
     public void test_it_sets_the_recipients() throws Exception {
-        when(templatePopulator.populateTemplate(Matchers.<String>any(), Matchers.<Map<String, Object>>any())).thenReturn("Template Contents");
+        when(templatePopulator
+            .populateTemplate(Matchers.<String>any(), Matchers.<Map<String, Object>>any()))
+            .thenReturn("Template Contents");
 
         internetAddresses.add(new InternetAddress("test@example.com"));
 
-        TemplatedEmail input = new TemplatedEmailImpl(
-                new ArrayList<>(),
-                "sender@example.com",
-                "Subject",
-                "html template",
-                new HashMap<>(),
-                "text template"
-        );
+        TemplatedEmail input =
+            new TemplatedEmailImpl(new ArrayList<>(), "sender@example.com", "Subject",
+                "html template", new HashMap<>(), "text template");
         HtmlEmail output = templatedEmailFactory.build(input);
 
         assertThat(output.getToAddresses(), equalTo(internetAddresses));
@@ -68,18 +64,15 @@ public class TemplatedEmailFactoryImplTest {
 
     @Test
     public void test_it_sets_from() throws Exception {
-        when(templatePopulator.populateTemplate(Matchers.<String>any(), Matchers.<Map<String, Object>>any())).thenReturn("Template Contents");
+        when(templatePopulator
+            .populateTemplate(Matchers.<String>any(), Matchers.<Map<String, Object>>any()))
+            .thenReturn("Template Contents");
 
         internetAddresses.add(new InternetAddress("test@example.com"));
 
-        TemplatedEmail input = new TemplatedEmailImpl(
-                new ArrayList<>(),
-                "sender@example.com",
-                "Subject",
-                "html template",
-                new HashMap<>(),
-                "text template"
-        );
+        TemplatedEmail input =
+            new TemplatedEmailImpl(new ArrayList<>(), "sender@example.com", "Subject",
+                "html template", new HashMap<>(), "text template");
         HtmlEmail output = templatedEmailFactory.build(input);
         InternetAddress expected = new InternetAddress("sender@example.com");
 
@@ -88,18 +81,15 @@ public class TemplatedEmailFactoryImplTest {
 
     @Test
     public void test_it_sets_subject() throws Exception {
-        when(templatePopulator.populateTemplate(Matchers.<String>any(), Matchers.<Map<String, Object>>any())).thenReturn("Template Contents");
+        when(templatePopulator
+            .populateTemplate(Matchers.<String>any(), Matchers.<Map<String, Object>>any()))
+            .thenReturn("Template Contents");
 
         internetAddresses.add(new InternetAddress("test@example.com"));
 
-        TemplatedEmail input = new TemplatedEmailImpl(
-                new ArrayList<>(),
-                "sender@example.com",
-                "Subject",
-                "html template",
-                new HashMap<>(),
-                "text template"
-        );
+        TemplatedEmail input =
+            new TemplatedEmailImpl(new ArrayList<>(), "sender@example.com", "Subject",
+                "html template", new HashMap<>(), "text template");
         HtmlEmail output = templatedEmailFactory.build(input);
 
         assertThat(output.getSubject(), equalTo("Subject"));
@@ -107,18 +97,14 @@ public class TemplatedEmailFactoryImplTest {
 
     @Test
     public void test_it_sets_html_template() throws Exception {
-        when(templatePopulator.populateTemplate(anyString(), Matchers.<Map<String, Object>>any())).thenReturn("Template Contents");
+        when(templatePopulator.populateTemplate(anyString(), Matchers.<Map<String, Object>>any()))
+            .thenReturn("Template Contents");
 
         internetAddresses.add(new InternetAddress("test@example.com"));
 
-        TemplatedEmail input = new TemplatedEmailImpl(
-                new ArrayList<>(),
-                "sender@example.com",
-                "Subject",
-                "html template",
-                new HashMap<>(),
-                "text template"
-        );
+        TemplatedEmail input =
+            new TemplatedEmailImpl(new ArrayList<>(), "sender@example.com", "Subject",
+                "html template", new HashMap<>(), "text template");
         HtmlEmail output = templatedEmailFactory.build(input);
 
         verify(output).setHtmlMsg("Template Contents");
@@ -126,18 +112,15 @@ public class TemplatedEmailFactoryImplTest {
 
     @Test
     public void test_it_sets_text_template() throws Exception {
-        when(templatePopulator.populateTemplate(any(String.class), Matchers.<Map<String, Object>>any())).thenReturn("Template Contents");
+        when(templatePopulator
+            .populateTemplate(any(String.class), Matchers.<Map<String, Object>>any()))
+            .thenReturn("Template Contents");
 
         internetAddresses.add(new InternetAddress("test@example.com"));
 
-        TemplatedEmail input = new TemplatedEmailImpl(
-                new ArrayList<>(),
-                "sender@example.com",
-                "Subject",
-                "html template",
-                new HashMap<>(),
-                "text template"
-        );
+        TemplatedEmail input =
+            new TemplatedEmailImpl(new ArrayList<>(), "sender@example.com", "Subject",
+                "html template", new HashMap<>(), "text template");
         HtmlEmail output = templatedEmailFactory.build(input);
 
         verify(output).setTextMsg("Template Contents");

--- a/src/test/java/uk/gov/homeoffice/emailapi/templatedemailfactory/serverconfig/HtmlEmailFactoryImplTest.java
+++ b/src/test/java/uk/gov/homeoffice/emailapi/templatedemailfactory/serverconfig/HtmlEmailFactoryImplTest.java
@@ -9,15 +9,8 @@ public class HtmlEmailFactoryImplTest {
 
     @Test
     public void test_it_sets_server_config() throws Exception {
-        HtmlEmailFactoryImpl subject = new HtmlEmailFactoryImpl(
-                "localhost",
-                25,
-                "",
-                "",
-                false,
-                true,
-                false
-        );
+        HtmlEmailFactoryImpl subject =
+            new HtmlEmailFactoryImpl("localhost", 25, "", "", false, true, false);
 
         assertThat(subject.getHtmlEmail().getHostName(), equalTo("localhost"));
         assertThat(subject.getHtmlEmail().getSmtpPort(), equalTo("25"));

--- a/src/test/java/uk/gov/homeoffice/emailapi/templatedemailfactory/templating/FreemarkerTemplatePopulatorImplTest.java
+++ b/src/test/java/uk/gov/homeoffice/emailapi/templatedemailfactory/templating/FreemarkerTemplatePopulatorImplTest.java
@@ -14,12 +14,17 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class FreemarkerTemplatePopulatorImplTest {
 
     @Test
-    public void test_it_gets_content_of_the_template() throws IOException, TemplateException, TemplatePopulatorException {
+    public void test_it_gets_content_of_the_template()
+        throws IOException, TemplateException, TemplatePopulatorParsingException,
+        TemplatePopulatorIOException {
         Configuration freemarkerConfiguration = mock(Configuration.class);
         Template freemarkerTemplate = mock(Template.class);
 
@@ -38,22 +43,73 @@ public class FreemarkerTemplatePopulatorImplTest {
             return null;
         }).when(freemarkerTemplate).process(eq(expectedDataModel), any(Writer.class));
 
-        FreemarkerTemplatePopulatorImpl subject = new FreemarkerTemplatePopulatorImpl(freemarkerConfiguration);
+        FreemarkerTemplatePopulatorImpl subject =
+            new FreemarkerTemplatePopulatorImpl(freemarkerConfiguration);
         String actual = subject.populateTemplate("template-name", expectedDataModel);
 
         assertThat(actual, equalTo("Hello, world!"));
     }
 
-    @Test(expected = TemplatePopulatorException.class)
-    public void test_it_wraps_exceptions_in() throws IOException, TemplateException, TemplatePopulatorException {
+    @Test(expected = TemplatePopulatorIOException.class)
+    public void test_it_wraps_exceptions_in_io_error()
+        throws IOException, TemplateException, TemplatePopulatorIOException,
+        TemplatePopulatorParsingException {
         Configuration freemarkerConfiguration = mock(Configuration.class);
         Template freemarkerTemplate = mock(Template.class);
 
         when(freemarkerConfiguration.getTemplate("template-name")).thenReturn(freemarkerTemplate);
         Map<String, Object> expectedDataModel = new HashMap<>();
-        doThrow(new IOException()).when(freemarkerTemplate).process(eq(expectedDataModel), any(Writer.class));
+        doThrow(new IOException()).when(freemarkerTemplate)
+            .process(eq(expectedDataModel), any(Writer.class));
 
-        FreemarkerTemplatePopulatorImpl subject = new FreemarkerTemplatePopulatorImpl(freemarkerConfiguration);
+        FreemarkerTemplatePopulatorImpl subject =
+            new FreemarkerTemplatePopulatorImpl(freemarkerConfiguration);
+        subject.populateTemplate("template-name", expectedDataModel);
+    }
+
+
+    @Test(expected = TemplatePopulatorParsingException.class)
+    public void test_it_wraps_exceptions_in_parse_error()
+        throws IOException, TemplateException, TemplatePopulatorIOException,
+        TemplatePopulatorParsingException {
+        Configuration freemarkerConfiguration = mock(Configuration.class);
+        Template freemarkerTemplate = mock(Template.class);
+
+        when(freemarkerConfiguration.getTemplate("template-name")).thenReturn(freemarkerTemplate);
+        Map<String, Object> expectedDataModel = new HashMap<>();
+        doThrow(new TemplateException(null)).when(freemarkerTemplate)
+            .process(eq(expectedDataModel), any(Writer.class));
+
+        FreemarkerTemplatePopulatorImpl subject =
+            new FreemarkerTemplatePopulatorImpl(freemarkerConfiguration);
+        subject.populateTemplate("template-name", expectedDataModel);
+    }
+
+
+    @Test(expected = TemplatePopulatorParsingException.class)
+    public void test_it_throws_a_parse_error_on_empty_email()
+        throws IOException, TemplateException, TemplatePopulatorIOException,
+        TemplatePopulatorParsingException {
+        Configuration freemarkerConfiguration = mock(Configuration.class);
+        Template freemarkerTemplate = mock(Template.class);
+
+        when(freemarkerConfiguration.getTemplate("template-name")).thenReturn(freemarkerTemplate);
+
+        Map<String, Object> expectedDataModel = new HashMap<>();
+
+        doAnswer(invocation -> {
+            Writer writer = (Writer) invocation.getArguments()[1];
+            try {
+                writer.write("   ");
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+
+            return null;
+        }).when(freemarkerTemplate).process(eq(expectedDataModel), any(Writer.class));
+
+        FreemarkerTemplatePopulatorImpl subject =
+            new FreemarkerTemplatePopulatorImpl(freemarkerConfiguration);
         subject.populateTemplate("template-name", expectedDataModel);
     }
 }


### PR DESCRIPTION
1. Firstly ensured that invalid Email Templates return a 400 error by @Valid-ing them
2. Then un-bundled the exceptions from the TemplatedEmailSender, and rather threw individual errors per problem cause
3. Next added exception handlers for those, and a nice human errors
4. Added logging to all of those error handlers at appropriate levels to ensure service managers are aware
5. And finally Added validation to entity for useful error messages

Fixes #21 
Fixes #22 
